### PR TITLE
Add login link in header

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -11,6 +11,9 @@ export default function Header() {
           <Link to="/about" className="text-blue-600 hover:underline">
             About
           </Link>
+          <Link to="/login" className="text-blue-600 hover:underline">
+            Login
+          </Link>
         </nav>
 
     </header>


### PR DESCRIPTION
## Summary
- add a Login link to the navigation in the header

## Testing
- `npm install` in `frontend`
- `npm run lint` *(fails: `@typescript-eslint/no-explicit-any` and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_687c9ce40c0c8323a7286fecbf53f6f4