### PR TITLE
Enable session cookies in frontend requests

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -14,9 +14,13 @@ export interface LoginResponse {
 }
 
 /** 新規作成 */
-export const signup = async (email: string, password: string): Promise<SignupResponse> => {
-  const res = await client.post("/signup", { email, password });
+export const signup = async (
+  email: string,
+  password: string,
+): Promise<SignupResponse> => {
+  await client.post("/signup", { email, password });
   // 本文が無ければデフォルトメッセージを付与
+  // const res = await client.post("/signup", { email, password });
   // return res.data ?? { message: "アカウントを作成しました" };
   return { message: "アカウントを作成しました。" };
 };

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -4,6 +4,7 @@ export const client = axios.create({
   // .env で VITE_API_URL を上書き可能にしておくと環境切り替えが楽
   baseURL: import.meta.env.VITE_API_URL || "http://localhost:8081",
   timeout: 10000,
+  withCredentials: true,
 });
 
 export default client;

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -21,8 +21,9 @@ export default function LoginForm() {
       const { message, token } = await login(email, password);
       if (token) saveToken(token);
       setResult(message);
-    } catch (e: any) {
-      setError(e.response?.data?.message || e.message);
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { message?: string } }; message?: string };
+      setError(err.response?.data?.message || err.message || String(e));
     }
   };
 

--- a/frontend/src/components/SignupForm.tsx
+++ b/frontend/src/components/SignupForm.tsx
@@ -17,8 +17,9 @@ export default function SignupForm() {
     try {
       const { message } = await signup(email, password);
       setResult(message);
-    } catch (e: any) {
-      setError(e.response?.data?.message || e.message);
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { message?: string } }; message?: string };
+      setError(err.response?.data?.message || err.message || String(e));
     }
   };
 

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -23,8 +23,9 @@ export default function About() {
     try {
       const { message } = await signup(email, password);
       setMsg(message);                  // ← 常に表示される
-    } catch (e: any) {
-      setErr(e.response?.data?.message || e.message);
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { message?: string } }; message?: string };
+      setErr(err.response?.data?.message || err.message || String(e));
     }
   };
 
@@ -35,8 +36,9 @@ export default function About() {
       const { message, token } = await login(email, password);
       if (token) saveToken(token);        // トークン保存
       setMsg(message);
-    } catch (e: any) {
-      setErr(e.response?.data?.message || e.message);
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { message?: string } }; message?: string };
+      setErr(err.response?.data?.message || err.message || String(e));
     }
   };
 


### PR DESCRIPTION
## Summary
- configure Axios client to include credentials
- fix lint errors in auth and UI components

## Testing
- `npm run lint`
- `npm run build`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c9d5ba750832382883fb7de3cd65e