### PR TITLE
Display user email in header when logged in

### DIFF
--- a/backend/handlers/auth.go
+++ b/backend/handlers/auth.go
@@ -2,68 +2,86 @@
 package handlers
 
 import (
-    "net/http"
-    "time"
+	"net/http"
+	"time"
 
-    "github.com/gin-gonic/gin"
-    "github.com/gin-contrib/sessions"
-    "golang.org/x/crypto/bcrypt"
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-gonic/gin"
+	"golang.org/x/crypto/bcrypt"
 
-    "github.com/takiyama-aki/go_app/database"
-    "github.com/takiyama-aki/go_app/models"
+	"github.com/takiyama-aki/go_app/database"
+	"github.com/takiyama-aki/go_app/helpers"
+	"github.com/takiyama-aki/go_app/models"
 )
 
 type SignUpRequest struct {
-    Email    string `json:"email" binding:"required,email"`
-    Password string `json:"password" binding:"required,min=8"`
+	Email    string `json:"email" binding:"required,email"`
+	Password string `json:"password" binding:"required,min=8"`
 }
 
 type LoginRequest struct {
-    Email    string `json:"email" binding:"required,email"`
-    Password string `json:"password" binding:"required"`
+	Email    string `json:"email" binding:"required,email"`
+	Password string `json:"password" binding:"required"`
 }
 
 // SignUp はユーザー登録のエンドポイント（スタブ）
 func SignUp(c *gin.Context) {
-    var req SignUpRequest
-    if err := c.ShouldBindJSON(&req); err != nil {
-        c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-        return
-    }
+	var req SignUpRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 
-    hash, _ := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
-    user := models.User{Email: req.Email, PasswordHash: string(hash), CreatedAt: time.Now()}
-    if err := database.DB.Create(&user).Error; err != nil {
-        c.JSON(http.StatusConflict, gin.H{"error": "email already in use"})
-        return
-    }
-    c.JSON(http.StatusCreated, gin.H{"id": user.ID, "email": user.Email})
+	hash, _ := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	user := models.User{Email: req.Email, PasswordHash: string(hash), CreatedAt: time.Now()}
+	if err := database.DB.Create(&user).Error; err != nil {
+		c.JSON(http.StatusConflict, gin.H{"error": "email already in use"})
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"id": user.ID, "email": user.Email})
 }
 
 // Login はログインのエンドポイント（スタブ）
 func Login(c *gin.Context) {
-    var req LoginRequest
-    if err := c.ShouldBindJSON(&req); err != nil {
-        c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-        return
-    }
+	var req LoginRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 
-    var user models.User
-    if err := database.DB.Where("email = ?", req.Email).First(&user).Error; err != nil {
-        c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
-        return
-    }
+	var user models.User
+	if err := database.DB.Where("email = ?", req.Email).First(&user).Error; err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
+		return
+	}
 
-    if bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(req.Password)) != nil {
-        c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
-        return
-    }
+	if bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(req.Password)) != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
+		return
+	}
 
-    sess := sessions.Default(c)
-    sess.Set("user_id", user.ID)
-    if err := sess.Save(); err != nil {
-        c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save session"})
-        return
-    }
-    c.JSON(http.StatusOK, gin.H{"message": "login successful"})
+	sess := sessions.Default(c)
+	sess.Set("user_id", user.ID)
+	if err := sess.Save(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save session"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "login successful"})
+}
+
+// GetMe returns the currently logged-in user's basic information.
+func GetMe(c *gin.Context) {
+	uid, ok := helpers.CurrentUserID(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	var user models.User
+	if err := database.DB.First(&user, uid).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch user"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"id": user.ID, "email": user.Email})
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -71,6 +71,9 @@ func main() {
 	auth := r.Group("/")
 	auth.Use(middleware.RequireLogin())
 
+	// ログイン中ユーザー取得
+	auth.GET("/me", handlers.GetMe)
+
 	// Trade CRUD
 	auth.GET("/trades", handlers.ListTrades)
 	auth.GET("/trades/:id", handlers.GetTrade)

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -30,3 +30,12 @@ export const login = (email: string, password: string) =>
   client
     .post<LoginResponse>("/login", { email, password })
     .then((r) => r.data);
+
+export interface MeResponse {
+  id: number;
+  email: string;
+}
+
+export const getCurrentUser = () =>
+  client.get<MeResponse>("/me").then((r) => r.data);
+

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,24 +1,34 @@
 import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { getCurrentUser } from "../api/auth";
 
 export default function Header() {
+  const { data } = useQuery({
+    queryKey: ["me"],
+    queryFn: getCurrentUser,
+    retry: false,
+  });
+
   return (
     <header className="h-14 flex items-center px-4 shadow">
       <h1 className="font-bold">Go&nbsp;Trade&nbsp;App</h1>
-              <nav className="space-x-4">
-          <Link to="/" className="text-blue-600 hover:underline">
-            Home
-          </Link>
-          <Link to="/about" className="text-blue-600 hover:underline">
-            About
-          </Link>
-          <Link to="/trades" className="text-blue-600 hover:underline">
+      <nav className="ml-auto space-x-4">
+        <Link to="/" className="text-blue-600 hover:underline">
+          Home
+        </Link>
+        <Link to="/about" className="text-blue-600 hover:underline">
+          About
+        </Link>
+        <Link to="/trades" className="text-blue-600 hover:underline">
           Trades
-          </Link>
-          <Link to="/login" className="text-blue-600 hover:underline">
-            Login
-          </Link>
-        </nav>
-
+        </Link>
+        <Link to="/login" className="text-blue-600 hover:underline">
+          Login
+        </Link>
+      </nav>
+      <span className="ml-4 text-sm text-gray-600">
+        {data?.email ?? "未ログイン"}
+      </span>
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- add `/me` endpoint to return user info
- expose `getCurrentUser` API
- show account email or `未ログイン` in header

## Testing
- `npm run lint`
- `npm run build`
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_687dedc5687c8323ade7df9eabd8c9cb