### PR TITLE
Implement auto-login and refresh header

### DIFF
--- a/backend/handlers/auth.go
+++ b/backend/handlers/auth.go
@@ -38,6 +38,14 @@ func SignUp(c *gin.Context) {
 		c.JSON(http.StatusConflict, gin.H{"error": "email already in use"})
 		return
 	}
+
+	sess := sessions.Default(c)
+	sess.Set("user_id", user.ID)
+	if err := sess.Save(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save session"})
+		return
+	}
+
 	c.JSON(http.StatusCreated, gin.H{"id": user.ID, "email": user.Email})
 }
 

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -3,6 +3,7 @@
 // ログインフォーム（/login を呼び出す）
 //-------------------------------------
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { login } from "../api/auth";
 import { useAuthStore } from "../store/auth";
 
@@ -13,6 +14,7 @@ export default function LoginForm() {
   const [error, setError]   = useState<string | null>(null);
 
   const saveToken = useAuthStore((s) => s.login);
+  const queryClient = useQueryClient();
 
   const handleLogin = async () => {
     setResult(null);
@@ -21,6 +23,7 @@ export default function LoginForm() {
       const { message, token } = await login(email, password);
       if (token) saveToken(token);
       setResult(message);
+      await queryClient.invalidateQueries({ queryKey: ["me"] });
     } catch (e: unknown) {
       const err = e as { response?: { data?: { message?: string } }; message?: string };
       setError(err.response?.data?.message || err.message || String(e));

--- a/frontend/src/components/SignupForm.tsx
+++ b/frontend/src/components/SignupForm.tsx
@@ -3,13 +3,15 @@
 // 新規作成フォーム（/signup を呼び出す）
 //-------------------------------------
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { signup } from "../api/auth";
 
 export default function SignupForm() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [result, setResult] = useState<string | null>(null);
-  const [error, setError]   = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
 
   const handleSignup = async () => {
     setResult(null);
@@ -17,6 +19,7 @@ export default function SignupForm() {
     try {
       const { message } = await signup(email, password);
       setResult(message);
+      await queryClient.invalidateQueries({ queryKey: ["me"] });
     } catch (e: unknown) {
       const err = e as { response?: { data?: { message?: string } }; message?: string };
       setError(err.response?.data?.message || err.message || String(e));

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,25 +1,24 @@
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { signup, login } from "../api/auth";
 import { useNavigate } from "react-router-dom";
-import { useAuthStore } from "../store/auth";
 
 export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
-  const saveToken = useAuthStore((s) => s.login);
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const handleSignup = async () => {
     await signup(email, password);
-    const { token } = await login(email, password);
-    if (token) saveToken(token);
+    await queryClient.invalidateQueries({ queryKey: ["me"] });
     navigate("/");
   };
 
   const handleLogin = async () => {
-    const { token } = await login(email, password);
-    if (token) saveToken(token);
+    await login(email, password);
+    await queryClient.invalidateQueries({ queryKey: ["me"] });
     navigate("/");
   };
 


### PR DESCRIPTION
## Summary
- auto-login users after sign up by saving the session
- refresh `/me` query on login or signup so header shows logged-in state
- update signup/login components to refresh header

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687df1237bf48323959000ce8abd8341