### PR TITLE
Fix auth flow to use session-based login

### DIFF
--- a/backend/handlers/auth.go
+++ b/backend/handlers/auth.go
@@ -77,6 +77,17 @@ func Login(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "login successful"})
 }
 
+// Logout clears the current session.
+func Logout(c *gin.Context) {
+	sess := sessions.Default(c)
+	sess.Clear()
+	if err := sess.Save(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to clear session"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "logout successful"})
+}
+
 // GetMe returns the currently logged-in user's basic information.
 func GetMe(c *gin.Context) {
 	uid, ok := helpers.CurrentUserID(c)

--- a/backend/main.go
+++ b/backend/main.go
@@ -73,6 +73,7 @@ func main() {
 
 	// ログイン中ユーザー取得
 	auth.GET("/me", handlers.GetMe)
+	auth.POST("/logout", handlers.Logout)
 
 	// Trade CRUD
 	auth.GET("/trades", handlers.ListTrades)

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -10,7 +10,6 @@ export interface SignupResponse {
 
 export interface LoginResponse {
   message: string;
-  token?: string;
 }
 
 /** 新規作成 */
@@ -30,6 +29,9 @@ export const login = (email: string, password: string) =>
   client
     .post<LoginResponse>("/login", { email, password })
     .then((r) => r.data);
+
+export const logout = () =>
+  client.post<{ message: string }>("/logout").then((r) => r.data);
 
 export interface MeResponse {
   id: number;

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,12 +1,17 @@
 import { Link } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
-import { getCurrentUser } from "../api/auth";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getCurrentUser, logout } from "../api/auth";
 
 export default function Header() {
+  const queryClient = useQueryClient();
   const { data } = useQuery({
     queryKey: ["me"],
     queryFn: getCurrentUser,
     retry: false,
+  });
+  const { mutate } = useMutation({
+    mutationFn: logout,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["me"] }),
   });
 
   return (
@@ -22,9 +27,15 @@ export default function Header() {
         <Link to="/trades" className="text-blue-600 hover:underline">
           Trades
         </Link>
-        <Link to="/login" className="text-blue-600 hover:underline">
-          Login
-        </Link>
+        {data ? (
+          <button onClick={() => mutate()} className="text-blue-600 hover:underline">
+            Logout
+          </button>
+        ) : (
+          <Link to="/login" className="text-blue-600 hover:underline">
+            Login
+          </Link>
+        )}
       </nav>
       <span className="ml-4 text-sm text-gray-600">
         {data?.email ?? "未ログイン"}

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -5,7 +5,6 @@
 import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { login } from "../api/auth";
-import { useAuthStore } from "../store/auth";
 
 export default function LoginForm() {
   const [email, setEmail] = useState("");
@@ -13,15 +12,13 @@ export default function LoginForm() {
   const [result, setResult] = useState<string | null>(null);
   const [error, setError]   = useState<string | null>(null);
 
-  const saveToken = useAuthStore((s) => s.login);
   const queryClient = useQueryClient();
 
   const handleLogin = async () => {
     setResult(null);
     setError(null);
     try {
-      const { message, token } = await login(email, password);
-      if (token) saveToken(token);
+      const { message } = await login(email, password);
       setResult(message);
       await queryClient.invalidateQueries({ queryKey: ["me"] });
     } catch (e: unknown) {

--- a/frontend/src/store/auth.ts
+++ b/frontend/src/store/auth.ts
@@ -5,25 +5,21 @@
 import { create } from "zustand";
 
 interface AuthState {
-  token: string | null;        // JWT など
   isLoggedIn: boolean;         // 認証フラグ
-  login:  (token: string) => void;
+  login: () => void;
   logout: () => void;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
-  token:      localStorage.getItem("token"),
-  isLoggedIn: !!localStorage.getItem("token"),
+  isLoggedIn: false,
 
-  /** トークン保存＆ログイン状態 ON */
-  login: (token) => {
-    localStorage.setItem("token", token);
-    set({ token, isLoggedIn: true });
+  /** ログイン状態 ON */
+  login: () => {
+    set({ isLoggedIn: true });
   },
 
-  /** トークン削除＆ログイン状態 OFF */
+  /** ログアウトで状態 OFF */
   logout: () => {
-    localStorage.removeItem("token");
-    set({ token: null, isLoggedIn: false });
+    set({ isLoggedIn: false });
   },
 }));


### PR DESCRIPTION
## Summary
- add logout endpoint in Go backend and route it
- update frontend API auth helpers for session cookies
- adjust login form and header to handle session-based login/logout
- simplify auth store to store only login state

## Testing
- `npm run lint`
- `npm run build`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687df4902f5c8323b0fad2b753c1d0d6