### PR TITLE
Update auth store usage

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,9 +1,11 @@
 import { Link } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getCurrentUser, logout } from "../api/auth";
+import { useAuthStore } from "../store/auth";
 
 export default function Header() {
   const queryClient = useQueryClient();
+  const { logout: setLogout } = useAuthStore();
   const { data } = useQuery({
     queryKey: ["me"],
     queryFn: getCurrentUser,
@@ -11,7 +13,10 @@ export default function Header() {
   });
   const { mutate } = useMutation({
     mutationFn: logout,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["me"] }),
+    onSuccess: () => {
+      setLogout();
+      queryClient.invalidateQueries({ queryKey: ["me"] });
+    },
   });
 
   return (

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -5,6 +5,7 @@
 import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { login } from "../api/auth";
+import { useAuthStore } from "../store/auth";
 
 export default function LoginForm() {
   const [email, setEmail] = useState("");
@@ -13,6 +14,7 @@ export default function LoginForm() {
   const [error, setError]   = useState<string | null>(null);
 
   const queryClient = useQueryClient();
+  const { login: setLogin } = useAuthStore();
 
   const handleLogin = async () => {
     setResult(null);
@@ -20,6 +22,7 @@ export default function LoginForm() {
     try {
       const { message } = await login(email, password);
       setResult(message);
+      setLogin();
       await queryClient.invalidateQueries({ queryKey: ["me"] });
     } catch (e: unknown) {
       const err = e as { response?: { data?: { message?: string } }; message?: string };

--- a/frontend/src/components/SignupForm.tsx
+++ b/frontend/src/components/SignupForm.tsx
@@ -5,6 +5,7 @@
 import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { signup } from "../api/auth";
+import { useAuthStore } from "../store/auth";
 
 export default function SignupForm() {
   const [email, setEmail] = useState("");
@@ -12,6 +13,7 @@ export default function SignupForm() {
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const queryClient = useQueryClient();
+  const { login: setLogin } = useAuthStore();
 
   const handleSignup = async () => {
     setResult(null);
@@ -19,6 +21,7 @@ export default function SignupForm() {
     try {
       const { message } = await signup(email, password);
       setResult(message);
+      setLogin();
       await queryClient.invalidateQueries({ queryKey: ["me"] });
     } catch (e: unknown) {
       const err = e as { response?: { data?: { message?: string } }; message?: string };

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { signup, login } from "../api/auth";
 import { useNavigate } from "react-router-dom";
+import { useAuthStore } from "../store/auth";
 
 export default function Login() {
   const [email, setEmail] = useState("");
@@ -9,15 +10,18 @@ export default function Login() {
 
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { login: setLogin } = useAuthStore();
 
   const handleSignup = async () => {
     await signup(email, password);
+    setLogin();
     await queryClient.invalidateQueries({ queryKey: ["me"] });
     navigate("/");
   };
 
   const handleLogin = async () => {
     await login(email, password);
+    setLogin();
     await queryClient.invalidateQueries({ queryKey: ["me"] });
     navigate("/");
   };


### PR DESCRIPTION
## Summary
- update Login page to set auth store after login/signup
- update LoginForm and SignupForm to update auth store
- update Header logout handling to update auth store

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687dfa051634832395c7c84ac434fbd3