### PR TITLE
Add Google OAuth login

### DIFF
--- a/.env
+++ b/.env
@@ -6,3 +6,6 @@ DB_PORT=5433
 APP_PORT=8081
 DB_HOST=localhost
 SESSION_KEY=changeme
+OAUTH_CLIENT_ID=your-client-id
+OAUTH_CLIENT_SECRET=your-client-secret
+OAUTH_REDIRECT_URL=http://localhost:8081/oauth/callback

--- a/backend/handlers/oauth.go
+++ b/backend/handlers/oauth.go
@@ -102,5 +102,6 @@ func OAuthCallback(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "login successful"})
+	// ログイン後はフロントエンドへリダイレクト
+	c.Redirect(http.StatusFound, "http://localhost:5173")
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,9 @@ services:
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
       DB_NAME: ${DB_NAME}
+      OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID}
+      OAUTH_CLIENT_SECRET: ${OAUTH_CLIENT_SECRET}
+      OAUTH_REDIRECT_URL: ${OAUTH_REDIRECT_URL}
       # もしアプリ側で別のポートを参照する場合は
       # APP_PORT: '8081'
     depends_on:

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -14,6 +14,11 @@ export default function Login() {
   const queryClient = useQueryClient();
   const { login: setLogin } = useAuthStore();
 
+  // Google ログイン処理
+  const handleGoogleLogin = () => {
+    window.location.href = "/oauth/login";
+  };
+
   // 新規ユーザー作成処理
   const handleSignup = async () => {
     await signup(email, password);
@@ -63,6 +68,12 @@ export default function Login() {
           disabled={!email || !password}
         >
           ログイン
+        </button>
+        <button
+          className="btn bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700"
+          onClick={handleGoogleLogin}
+        >
+          Googleでログイン
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add OAuth environment variables in `.env`
- pass OAuth configuration to API service in `docker-compose.yml`
- redirect to frontend after OAuth login completes
- implement Google login button on the login page

## Testing
- `npm -C frontend run lint`
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_688239c952108323a3de26c18ce47bff