### PR TITLE
Fix OAuth login redirect

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -16,7 +16,8 @@ export default function Login() {
 
   // Google ログイン処理
   const handleGoogleLogin = () => {
-    window.location.href = "/oauth/login";
+    const baseUrl = import.meta.env.VITE_API_URL || "http://localhost:8081";
+    window.location.href = `${baseUrl}/oauth/login`;
   };
 
   // 新規ユーザー作成処理


### PR DESCRIPTION
## Summary
- fix Google login redirect to use backend URL

## Testing
- `npm install` in `frontend`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68823db916ec832392539f4559c32396